### PR TITLE
Fix SQLite database path resolution for Prisma client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@
 SPOTIFY_CLIENT_ID=""
 SPOTIFY_CLIENT_SECRET=""
 # Database file
-DATABASE_URL="file:./data/albumrater.sqlite"
+DATABASE_URL="file:../data/albumrater.sqlite"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ npm install
 ```
 
 2. Create `.env.local` based on `.env.example` and fill in your Spotify credentials.
+   The default `DATABASE_URL` points to `file:../data/albumrater.sqlite`,
+   which resolves to `data/albumrater.sqlite` in the project root.
 
 3. Generate Prisma client and run the initial migration:
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,10 +1,26 @@
 import { PrismaClient } from '@prisma/client';
+import path from 'path';
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+// Resolve relative SQLite paths so the database file is found regardless of
+// the process working directory. Prisma resolves paths relative to the schema
+// file, which lives in the `prisma` directory.
+const resolveUrl = (url: string | undefined) => {
+  if (!url) return url;
+  if (!url.startsWith('file:')) return url;
+  const relative = url.replace(/^file:/, '');
+  const schemaDir = path.join(process.cwd(), 'prisma');
+  const absolute = path.resolve(schemaDir, relative);
+  return `file:${absolute}`;
+};
+
+const datasourceUrl = resolveUrl(process.env.DATABASE_URL);
 
 export const prisma =
   globalForPrisma.prisma ||
   new PrismaClient({
+    datasources: { db: { url: datasourceUrl } },
     log: ['error', 'warn'],
   });
 


### PR DESCRIPTION
## Summary
- resolve relative SQLite URLs to absolute path so Prisma can open the database
- document correct DATABASE_URL and update example env file

## Testing
- `SPOTIFY_CLIENT_ID=1 SPOTIFY_CLIENT_SECRET=1 npx vitest run` (fails: Foreign key constraint violated)


------
https://chatgpt.com/codex/tasks/task_e_68aa1006a27483209c42e6c235471f90